### PR TITLE
URL Cleanup

### DIFF
--- a/deploy/hawq_install.sh
+++ b/deploy/hawq_install.sh
@@ -195,5 +195,5 @@ echo "        This will install MADlib objects into a Greenplum database named \
 echo "        running on server \"mdw\" on port 5432. Installer will try to login as \"gpadmin\""
 echo "        and will prompt for password. The target schema will be \"madlib\"."
 echo "For additional options run: madpack --help"
-echo "Release notes and additional documentation can be found at http://madlib.apache.org/"
+echo "Release notes and additional documentation can be found at https://madlib.apache.org/"
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	(the "License"); you may not use this file except in compliance with
 	the License. You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+	https://www.apache.org/licenses/LICENSE-2.0
 
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,

--- a/tool/docker_start.sh
+++ b/tool/docker_start.sh
@@ -7,7 +7,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/tool/jenkins/jenkins_build.sh
+++ b/tool/jenkins/jenkins_build.sh
@@ -7,7 +7,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/tool/jenkins/rat_check.sh
+++ b/tool/jenkins/rat_check.sh
@@ -7,7 +7,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://madlib.apache.org/ migrated to:  
  https://madlib.apache.org/ ([https](https://madlib.apache.org/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance